### PR TITLE
Dockerfile: install sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ RUN apt-get update && \
                        ros-humble-ros2-controllers
 
 RUN apt-get update && \
-    apt-get install -y bash-completion
+    apt-get install -y bash-completion \
+                       sudo


### PR DESCRIPTION
This installs sudo as it may be useful in development to install the missing ROS packages at runtime.

Important: This should be removed once the docker image is considered as stable enought for development purpose.