### PR TITLE
robot_description: install models and sets GAZEBO_RESOURCE_PATH

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -122,5 +122,4 @@ if [ ! -f install/setup.bash ]; then
 	source /opt/ros/humble/setup.bash
 else
 	source install/setup.bash
-	export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11"
 fi

--- a/.bashrc
+++ b/.bashrc
@@ -122,5 +122,5 @@ if [ ! -f install/setup.bash ]; then
 	source /opt/ros/humble/setup.bash
 else
 	source install/setup.bash
-	export GAZEBO_RESOURCE_PATH="$PWD/src/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
+	export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
 fi

--- a/.bashrc
+++ b/.bashrc
@@ -122,5 +122,5 @@ if [ ! -f install/setup.bash ]; then
 	source /opt/ros/humble/setup.bash
 else
 	source install/setup.bash
-	export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
+	export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11"
 fi

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
 6. **Export the settings**
 
     ```bash
-    export GAZEBO_RESOURCE_PATH="~/Robot5A-Simulation/src/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
+    export GAZEBO_RESOURCE_PATH="~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
     export QT_QPA_PLATFORM=xcb
     ```
 
@@ -112,7 +112,7 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
     ```bash
     echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
     echo "source ~/Robot5A-Simulation/install/setup.bash" >> ~/.bashrc
-    echo "export GAZEBO_RESOURCE_PATH=\"~/Robot5A-Simulation/src/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11\"" >> ~/.bashrc
+    echo "export GAZEBO_RESOURCE_PATH=\"~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11\"" >> ~/.bashrc
     echo "export QT_QPA_PLATFORM=xcb" >> ~/.bashrc
     ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
 6. **Export the settings**
 
     ```bash
-    export GAZEBO_RESOURCE_PATH="~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
+    export GAZEBO_RESOURCE_PATH="~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11"
     export QT_QPA_PLATFORM=xcb
     ```
 
@@ -112,7 +112,7 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
     ```bash
     echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
     echo "source ~/Robot5A-Simulation/install/setup.bash" >> ~/.bashrc
-    echo "export GAZEBO_RESOURCE_PATH=\"~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11\"" >> ~/.bashrc
+    echo "export GAZEBO_RESOURCE_PATH=\"~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11\"" >> ~/.bashrc
     echo "export QT_QPA_PLATFORM=xcb" >> ~/.bashrc
     ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
 6. **Export the settings**
 
     ```bash
-    export GAZEBO_RESOURCE_PATH="~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11"
     export QT_QPA_PLATFORM=xcb
     ```
 
@@ -112,7 +111,6 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
     ```bash
     echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
     echo "source ~/Robot5A-Simulation/install/setup.bash" >> ~/.bashrc
-    echo "export GAZEBO_RESOURCE_PATH=\"~/Robot5A-Simulation/install/robot_description:/usr/share/gazebo-11\"" >> ~/.bashrc
     echo "export QT_QPA_PLATFORM=xcb" >> ~/.bashrc
     ```
 

--- a/launch.sh
+++ b/launch.sh
@@ -3,5 +3,4 @@
 set -e
 
 source install/setup.bash
-export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11"
 exec ros2 launch robot_control visual_sim.launch.py

--- a/launch.sh
+++ b/launch.sh
@@ -3,5 +3,5 @@
 set -e
 
 source install/setup.bash
-export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
+export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11"
 exec ros2 launch robot_control visual_sim.launch.py

--- a/launch.sh
+++ b/launch.sh
@@ -3,5 +3,5 @@
 set -e
 
 source install/setup.bash
-export GAZEBO_RESOURCE_PATH="$PWD/src/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
+export GAZEBO_RESOURCE_PATH="$PWD/install/robot_description/share/robot_description:/usr/share/gazebo-11/models:/usr/share/gazebo-11"
 exec ros2 launch robot_control visual_sim.launch.py

--- a/src/robot_control/launch/visual_sim.launch.py
+++ b/src/robot_control/launch/visual_sim.launch.py
@@ -11,6 +11,7 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
+    AppendEnvironmentVariable,
     IncludeLaunchDescription,
     ExecuteProcess,
     RegisterEventHandler,
@@ -210,9 +211,16 @@ def generate_launch_description():
         parameters=[{"use_sim_time": True}],
     )
 
+    # Append the resource path
+    set_env_vars_resources = AppendEnvironmentVariable(
+        'GAZEBO_RESOURCE_PATH',
+        os.pathsep.join([share_dir, "/usr/share/gazebo-11"])
+    )
+
     # Return the LaunchDescription
     return LaunchDescription(
         [
+            set_env_vars_resources,
             num_cameras_arg,  # Added the launch argument
             Node(
                 package='joint_state_publisher',

--- a/src/robot_description/CMakeLists.txt
+++ b/src/robot_description/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(ros2_controllers REQUIRED)  # This will bring in joint_state_contro
 find_package(robot_state_publisher REQUIRED)
 
 # Install directories
-install(DIRECTORY launch urdf meshes config worlds media
+install(DIRECTORY launch urdf meshes config worlds media models
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/src/robot_description/models/aruco_block_long/model.sdf
+++ b/src/robot_description/models/aruco_block_long/model.sdf
@@ -18,7 +18,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://aruco_block_long/meshes/block_long.dae</uri>
+            <uri>model://aruco_block_long</uri>
           </mesh>
         </geometry>
         <surface>
@@ -34,7 +34,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://aruco_block_long/meshes/block_long.dae</uri>
+            <uri>model://aruco_block_long</uri>
           </mesh>
         </geometry>
       </visual>

--- a/src/robot_description/models/checkerboard/checkerboard_plane.sdf
+++ b/src/robot_description/models/checkerboard/checkerboard_plane.sdf
@@ -7,7 +7,7 @@
         <geometry>
           <mesh>
             <scale>0.3 0.3 0.3</scale>
-            <uri>model://checkerboard_plane/meshes/checkerboard_plane.dae</uri>
+            <uri>model://checkerboard_plane</uri>
           </mesh>
         </geometry>
       </visual>


### PR DESCRIPTION
This installs the models to share state directory and appends the robot_control's models directory to the environ GAZEBO_RESOURCE_PATH, using the action AppendEnvironmentVariable.

Note: It sets the gazebo-11 system's directories too, to workaround some missing bits.