### PR TITLE
README.md: add missing ros-humble-ros-base package

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
         ros-humble-joint-state-publisher \
         ros-humble-joint-trajectory-controller \
         ros-humble-moveit \
-        ros-humble-robot-state-publisher \
+        ros-humble-ros-base \
         ros-humble-ros2-control \
         ros-humble-ros2-controllers \
         ros-humble-ros2bag \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
     sudo apt-get install -y \
         libgeometric-shapes-dev \
         meshlab \
+        ros-humble-diagnostic-updater \
         ros-humble-gazebo-ros-pkgs \
         ros-humble-gazebo-ros2-control \
         ros-humble-joint-state-broadcaster \
@@ -66,13 +67,12 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
         ros-humble-robot-state-publisher \
         ros-humble-ros2-control \
         ros-humble-ros2-controllers \
+        ros-humble-ros2bag \
         ros-humble-rqt \
         ros-humble-rqt-graph \
-        ros-humble-xacro \
-        ros-humble-diagnostic-updater \
         ros-humble-rviz2 \
         ros-humble-tf2-tools \
-        ros-humble-ros2bag
+        ros-humble-xacro
     ```
 
 


### PR DESCRIPTION
This adds the package ros-humble-ros-base package that is required to
run command ros launch.

Note: The package ros-humble-robot-state-publisher is removed as it is
installed by depedency of ros-humble-ros-base.