### PR TITLE
robot_description: export gazebo paths to package

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -118,8 +118,8 @@ fi
 
 # source the setup files
 # https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#add-sourcing-to-your-shell-startup-script
-if [ ! -f install/setup.bash ]; then
-	source /opt/ros/humble/setup.bash
-else
-	source install/setup.bash
-fi
+for i in /opt/ros/humble/setup.bash install/setup.bash; do
+  if [ -f "$i" ]; then
+    . "$i"
+  fi
+done

--- a/.bashrc
+++ b/.bashrc
@@ -118,7 +118,8 @@ fi
 
 # source the setup files
 # https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#add-sourcing-to-your-shell-startup-script
-for i in /opt/ros/humble/setup.bash install/setup.bash; do
+# https://classic.gazebosim.org/tutorials?tut=ros2_installing#Introduction
+for i in /opt/ros/humble/setup.bash /usr/share/gazebo/setup.bash install/setup.bash; do
   if [ -f "$i" ]; then
     . "$i"
   fi

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This project simulates and controls a robotic arm using **ROS2 Humble**, **Gazeb
 
     ```bash
     echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+    echo "source /usr/share/gazebo/setup.bash" >> ~/.bashrc
     echo "source ~/Robot5A-Simulation/install/setup.bash" >> ~/.bashrc
     echo "export QT_QPA_PLATFORM=xcb" >> ~/.bashrc
     ```
@@ -173,6 +174,7 @@ __Note__: The run-command file [.bashrc](.bashrc) sources the necessary bits so 
 Start the Gazebo simulation environment with the robotic arm using MoveIt.
 
 ```bash
+source /usr/share/gazebo/setup.bash
 ros2 launch robot_control visual_sim.launch.py 
 ```
 N.B. : It's also possible to control the arm using rviz2

--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,7 @@
 
 set -e
 
+# source the setup files
+# https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files
 source /opt/ros/humble/setup.bash
 exec colcon build

--- a/launch.sh
+++ b/launch.sh
@@ -4,7 +4,8 @@ set -e
 
 # source the setup files
 # https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files
-for i in /opt/ros/humble/setup.bash install/setup.bash; do
+# https://classic.gazebosim.org/tutorials?tut=ros2_installing#Introduction
+for i in /opt/ros/humble/setup.bash /usr/share/gazebo/setup.bash install/setup.bash; do
   if [ -f "$i" ]; then
     . "$i"
   fi

--- a/launch.sh
+++ b/launch.sh
@@ -2,5 +2,11 @@
 
 set -e
 
-source install/setup.bash
+# source the setup files
+# https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files
+for i in /opt/ros/humble/setup.bash install/setup.bash; do
+  if [ -f "$i" ]; then
+    . "$i"
+  fi
+done
 exec ros2 launch robot_control visual_sim.launch.py

--- a/rqt.sh
+++ b/rqt.sh
@@ -2,5 +2,11 @@
 
 set -e
 
-source /opt/ros/humble/setup.bash
+# source the setup files
+# https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files
+for i in /opt/ros/humble/setup.bash install/setup.bash; do
+  if [ -f "$i" ]; then
+    . "$i"
+  fi
+done
 exec rqt "$@"

--- a/src/robot_control/launch/visual_sim.launch.py
+++ b/src/robot_control/launch/visual_sim.launch.py
@@ -211,6 +211,12 @@ def generate_launch_description():
         parameters=[{"use_sim_time": True}],
     )
 
+    # Append the model path
+    set_env_vars_models = AppendEnvironmentVariable(
+        'GAZEBO_MODEL_PATH',
+        os.path.join(share_dir, "models")
+    )
+
     # Append the resource path
     set_env_vars_resources = AppendEnvironmentVariable(
         'GAZEBO_RESOURCE_PATH',
@@ -220,6 +226,7 @@ def generate_launch_description():
     # Return the LaunchDescription
     return LaunchDescription(
         [
+            set_env_vars_models,
             set_env_vars_resources,
             num_cameras_arg,  # Added the launch argument
             Node(

--- a/src/robot_control/launch/visual_sim.launch.py
+++ b/src/robot_control/launch/visual_sim.launch.py
@@ -11,7 +11,6 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
-    AppendEnvironmentVariable,
     IncludeLaunchDescription,
     ExecuteProcess,
     RegisterEventHandler,
@@ -211,23 +210,9 @@ def generate_launch_description():
         parameters=[{"use_sim_time": True}],
     )
 
-    # Append the model path
-    set_env_vars_models = AppendEnvironmentVariable(
-        'GAZEBO_MODEL_PATH',
-        os.path.join(share_dir, "models")
-    )
-
-    # Append the resource path
-    set_env_vars_resources = AppendEnvironmentVariable(
-        'GAZEBO_RESOURCE_PATH',
-        share_dir
-    )
-
     # Return the LaunchDescription
     return LaunchDescription(
         [
-            set_env_vars_models,
-            set_env_vars_resources,
             num_cameras_arg,  # Added the launch argument
             Node(
                 package='joint_state_publisher',

--- a/src/robot_control/launch/visual_sim.launch.py
+++ b/src/robot_control/launch/visual_sim.launch.py
@@ -214,7 +214,7 @@ def generate_launch_description():
     # Append the resource path
     set_env_vars_resources = AppendEnvironmentVariable(
         'GAZEBO_RESOURCE_PATH',
-        os.pathsep.join([share_dir, "/usr/share/gazebo-11"])
+        share_dir
     )
 
     # Return the LaunchDescription

--- a/src/robot_description/package.xml
+++ b/src/robot_description/package.xml
@@ -24,5 +24,7 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <gazebo_ros gazebo_model_path="${prefix}/models"/>
+    <gazebo_ros gazebo_media_path="${prefix}"/>
   </export>
 </package>


### PR DESCRIPTION
This exports the gazebo_model_path and gazebo_media_path (i.e. resource)
to automatically make the workspace resources and models to ROS Gazebo.
See [1][2][3].

Note: It that removes the needs to manually append these directories via
the environment variables GAZEBO_RESOURCE_PATH and GAZEBO_MODEL_PATH.
The python module gazebo_ros_paths.py[4] extracts the paths from the
list of package.xml; the two python launch scripts gzserver.launch.py
and gzclient.launch.py uses that module to concatenate these path to the
environment variables[5][6]. The third launch script gazebo.launch.py
launches the Gazebo server and client script.

[1]: https://docs.ros.org/en/humble/Tutorials/Intermediate/URDF/Using-a-URDF-in-Gazebo.html#side-note-configuring-meshes
[2]: https://classic.gazebosim.org/tutorials?tut=ros_roslaunch
[3]: https://wiki.ros.org/simulator_gazebo/GazeboConfiguration
[4]: https://github.com/ros-simulation/gazebo_ros_pkgs/blob/3.7.0/gazebo_ros/scripts/gazebo_ros_paths.py#L53-L65
[5]: https://github.com/ros-simulation/gazebo_ros_pkgs/blob/3.7.0/gazebo_ros/launch/gzserver.launch.py#L65-L78
[6]: https://github.com/ros-simulation/gazebo_ros_pkgs/blob/3.7.0/gazebo_ros/launch/gzclient.launch.py#L40-L53
[7]: https://github.com/ros-simulation/gazebo_ros_pkgs/blob/3.7.0/gazebo_ros/launch/gazebo.launch.py#L35-L43